### PR TITLE
Add resilience against invalid syntax

### DIFF
--- a/csharp/hashtopussy/hashcatClass.cs
+++ b/csharp/hashtopussy/hashcatClass.cs
@@ -438,16 +438,15 @@ namespace hashtopussy
             catch
             {
                 Console.WriteLine("Something went wrong with keyspace measuring");
+                return false;
             }
-            finally
+            if (hcProcKeyspace.ExitCode != 0)
             {
-                if (hcProcKeyspace.ExitCode != 0)
-                {
-                    Console.WriteLine("Something went wrong with keyspace measuring");
-                }
-
-                hcProcKeyspace.Close();
+                Console.WriteLine("Something went wrong with keyspace measuring");
+                return false;
             }
+
+            hcProcKeyspace.Close();
 
             parseKeyspace(stdOutSingle,ref keySpace);
 


### PR DESCRIPTION
Prevents the agent from fully crashing on keyspace parse errors